### PR TITLE
Drafted stereochemistry layers

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,9 +50,6 @@ pub enum Error<Idx> {
     /// Unrecognized layer prefix character after the main layer
     #[error("Unrecognized layer prefix: '{0}'")]
     UnrecognizedLayerPrefix(char),
-    /// TODO! TEMPORARY ERROR TO REMOVE!
-    #[error("Unimplemented feature: {0}")]
-    UnimplementedFeature(&'static str),
 }
 
 /// Errors that can occur while tokenizing the atom connection layer.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,6 +44,9 @@ pub enum Error<Idx> {
     /// Invalid isotope specification in the `/i` layer.
     #[error("Invalid isotope value: '{0}'")]
     InvalidIsotopeValue(char),
+    /// Invalid stereochemistry value.
+    #[error("Invalid stereo value: '{0}'")]
+    InvalidStereoValue(char),
     /// Unrecognized layer prefix character after the main layer
     #[error("Unrecognized layer prefix: '{0}'")]
     UnrecognizedLayerPrefix(char),

--- a/src/impls/from_str.rs
+++ b/src/impls/from_str.rs
@@ -3,7 +3,13 @@ use core::str::FromStr;
 use crate::{
     errors::Error,
     inchi::{
-        InChI, IsotopeLayer, MainLayer, charge_layer::ChargeSubLayer, proton_layer::ProtonSublayer,
+        InChI, IsotopeLayer, MainLayer,
+        charge_layer::ChargeSubLayer,
+        proton_layer::ProtonSublayer,
+        stereochemistry_layer::{
+            AlleneSublayer, DoubleBondSublayer, StereoChemistryInformationSublayer,
+            StereochemistryLayer, TetrahedralSublayer,
+        },
     },
     traits::{
         parse::{ConsumeStr, PrefixFromStrWithContext},
@@ -46,16 +52,27 @@ impl<V: Version> FromStr for InChI<V> {
 
         let proton = ProtonSublayer::try_build_layer(&mut layer_remainder, ())?;
 
-        // Skip stereo layers (b, t, m, s) that are not yet parsed.
-        // These are known-good prefixes, so no further validation needed.
-        while layer_remainder.starts_with('b')
-            || layer_remainder.starts_with('t')
-            || layer_remainder.starts_with('m')
-            || layer_remainder.starts_with('s')
+        let double_bond = DoubleBondSublayer::try_build_layer(
+            &mut layer_remainder,
+            main_layer.chemical_formula(),
+        )?;
+        let tetrahedral = TetrahedralSublayer::try_build_layer(
+            &mut layer_remainder,
+            main_layer.chemical_formula(),
+        )?;
+        let allene = AlleneSublayer::try_build_layer(&mut layer_remainder, ())?;
+        let stereo_info =
+            StereoChemistryInformationSublayer::try_build_layer(&mut layer_remainder, ())?;
+
+        let stereochemistry = if double_bond.is_some()
+            || tetrahedral.is_some()
+            || allene.is_some()
+            || stereo_info.is_some()
         {
-            let (_, rest) = layer_remainder.split_once('/').unwrap_or(("", ""));
-            layer_remainder = rest;
-        }
+            Some(StereochemistryLayer { double_bond, tetrahedral, allene, stereo_info })
+        } else {
+            None
+        };
 
         let isotope = IsotopeLayer::try_build_layer(
             &mut layer_remainder,
@@ -78,7 +95,7 @@ impl<V: Version> FromStr for InChI<V> {
             main_layer,
             charge,
             proton,
-            stereochemistry: None,
+            stereochemistry,
             isotope,
             fixed_hydrogen: None,
             reconnected: None,

--- a/src/impls/from_str.rs
+++ b/src/impls/from_str.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::str::FromStr;
 
 use crate::{
@@ -5,6 +6,7 @@ use crate::{
     inchi::{
         InChI, IsotopeLayer, MainLayer,
         charge_layer::ChargeSubLayer,
+        isotope_layer::IsotopeComponent,
         proton_layer::ProtonSublayer,
         stereochemistry_layer::{
             AlleneSublayer, DoubleBondSublayer, StereoChemistryInformationSublayer,
@@ -17,6 +19,54 @@ use crate::{
     },
     version::Version,
 };
+
+/// Parses a proton-only InChI (no chemical formula).
+///
+/// After the `/` separator, the input starts with `p` and may optionally
+/// include an isotope layer in the form `/i/hXY`.
+fn parse_proton_only<V: Version>(mut s: &str) -> Result<InChI<V>, Error<u16>> {
+    let proton = ProtonSublayer::try_build_layer(&mut s, ())?;
+
+    // Parse optional isotope layer: only `/i/hXY` form is valid here
+    // (empty atom body + hydrogen isotope sublayer).
+    let isotope = if s.starts_with(IsotopeLayer::PREFIX) {
+        // Consume the "i" segment
+        let (_, mut remainder) = s.split_once('/').unwrap_or((s, ""));
+
+        // Check for hydrogen isotope sublayer (/hD, /hT, /hH)
+        let hydrogens = if remainder.starts_with('h')
+            && remainder.as_bytes().get(1).is_some_and(|&b| b == b'D' || b == b'T' || b == b'H')
+        {
+            let (h_seg, rest) = remainder.split_once('/').unwrap_or((remainder, ""));
+            remainder = rest;
+            super::isotope_layer::parse_h_isotope_segment(h_seg)?
+        } else {
+            Vec::new()
+        };
+
+        s = remainder;
+        Some(IsotopeLayer {
+            components: alloc::vec![IsotopeComponent { atoms: Vec::new(), hydrogens }],
+        })
+    } else {
+        None
+    };
+
+    if !s.is_empty() {
+        return Err(Error::UnrecognizedLayerPrefix(s.chars().next().unwrap_or('/')));
+    }
+
+    Ok(InChI {
+        main_layer: None,
+        charge: None,
+        proton,
+        stereochemistry: None,
+        isotope,
+        fixed_hydrogen: None,
+        reconnected: None,
+        _version: core::marker::PhantomData,
+    })
+}
 
 impl<V: Version> FromStr for InChI<V> {
     type Err = Error<u16>;
@@ -37,10 +87,9 @@ impl<V: Version> FromStr for InChI<V> {
             return Err(Self::Err::MissingForwardSlash("Missing chemical formula forward slash"));
         };
 
-        // If the next token is a lowercase 'p' then this means that we don't have
-        // a main layer and we skip it
+        // Proton-only InChIs have no chemical formula — just /p and optionally /i
         if s.starts_with(ProtonSublayer::PREFIX) {
-            return Err(Error::UnimplementedFeature("Proton-only InChIs not yet supported"));
+            return parse_proton_only(s);
         }
 
         // Parse the main layer (formula, connections, hydrogens).
@@ -92,7 +141,7 @@ impl<V: Version> FromStr for InChI<V> {
         }
 
         Ok(InChI {
-            main_layer,
+            main_layer: Some(main_layer),
             charge,
             proton,
             stereochemistry,

--- a/src/impls/isotope_layer.rs
+++ b/src/impls/isotope_layer.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Parses hydrogen isotope specs from a segment like `hD2`, `hT`, `hDT3`.
-fn parse_h_isotope_segment(s: &str) -> Result<Vec<IsotopeHydrogen>, Error<u16>> {
+pub(crate) fn parse_h_isotope_segment(s: &str) -> Result<Vec<IsotopeHydrogen>, Error<u16>> {
     let s = s.strip_prefix('h').ok_or(Error::InvalidIsotopeValue('h'))?;
     let mut hydrogens = Vec::new();
     let mut chars = s.chars().peekable();

--- a/src/impls/main_layer/atom_connection_layer/connection_layer_token_iter.rs
+++ b/src/impls/main_layer/atom_connection_layer/connection_layer_token_iter.rs
@@ -84,6 +84,9 @@ impl<Idx: IndexLike> Iterator for ConnectionLayerTokenIter<'_, Idx> {
                         };
                     sub_tokens.push(sub_token);
                 }
+                if !sub_tokens.is_empty() {
+                    branch_tokens.push(sub_tokens);
+                }
                 ConnectionLayerToken::Branch(branch_tokens)
             }
             ConnectionLayerSubToken::CloseParenthesis => {

--- a/src/impls/main_layer/atom_connection_layer/connection_layer_token_iter/sub_tokens.rs
+++ b/src/impls/main_layer/atom_connection_layer/connection_layer_token_iter/sub_tokens.rs
@@ -77,7 +77,7 @@ where
         }
         let token = match self.chars.next()? {
             '(' => ConnectionLayerSubToken::OpenParenthesis,
-            ')' => ConnectionLayerSubToken::CloseParenthesis,
+            ')' => return Some(Ok(ConnectionLayerSubToken::CloseParenthesis)),
             ',' => ConnectionLayerSubToken::Comma,
             '-' => ConnectionLayerSubToken::Dash,
             unexpected_char => {

--- a/src/impls/stereochemistry_layer.rs
+++ b/src/impls/stereochemistry_layer.rs
@@ -1,44 +1,723 @@
-use core::str::FromStr;
+use alloc::vec::Vec;
+
+use molecular_formulas::{BaselineDigit, InChIFormula, MolecularFormula, try_fold_number};
 
 use crate::{
     errors::Error,
     inchi::stereochemistry_layer::{
-        AlleneSublayer, DoubleBondSublayer, StereoChemistryInformationSublayer,
-        StereochemistryLayer, TetrahedralSublayer,
+        AlleneSublayer, DoubleBondStereo, DoubleBondSublayer, StereoChemistryInformationSublayer,
+        StereoParity, TetrahedralStereo, TetrahedralSublayer,
+    },
+    traits::{
+        parse::{FromStrWithContext, PrefixFromStrWithContext},
+        prefix::Prefix,
     },
 };
 
-impl FromStr for StereochemistryLayer {
-    type Err = crate::errors::Error<usize>;
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Err(Error::UnimplementedFeature("Stereochemistry layer not implemented yet !"))
+/// Parses a parity character (`+`, `-`, `?`) into a `StereoParity`.
+fn parse_parity(c: char) -> Result<StereoParity, Error<u16>> {
+    match c {
+        '+' => Ok(StereoParity::Plus),
+        '-' => Ok(StereoParity::Minus),
+        '?' => Ok(StereoParity::Unknown),
+        c => Err(Error::InvalidStereoValue(c)),
     }
 }
 
-impl FromStr for AlleneSublayer {
-    type Err = crate::errors::Error<usize>;
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Err(Error::UnimplementedFeature("AlleneSublayer not implemented yet !"))
+/// Parses a single double bond spec like `12-11+`.
+fn parse_double_bond_spec(spec: &str) -> Result<DoubleBondStereo, Error<u16>> {
+    let mut chars = spec.chars().peekable();
+
+    // Parse first atom index (1-based)
+    let atom1_1based = match try_fold_number::<u16, BaselineDigit, _>(&mut chars) {
+        Some(Ok(n)) if n > 0 => n,
+        _ => {
+            return Err(Error::InvalidStereoValue(spec.chars().next().unwrap_or('?')));
+        }
+    };
+
+    // Consume '-' separator
+    match chars.next() {
+        Some('-') => {}
+        Some(c) => return Err(Error::InvalidStereoValue(c)),
+        None => return Err(Error::InvalidStereoValue('-')),
+    }
+
+    // Parse second atom index (1-based)
+    let atom2_1based = match try_fold_number::<u16, BaselineDigit, _>(&mut chars) {
+        Some(Ok(n)) if n > 0 => n,
+        _ => {
+            return Err(Error::InvalidStereoValue(chars.next().unwrap_or('?')));
+        }
+    };
+
+    // Parse parity
+    let parity = match chars.next() {
+        Some(c) => parse_parity(c)?,
+        None => return Err(Error::InvalidStereoValue('?')),
+    };
+
+    if chars.next().is_some() {
+        return Err(Error::InvalidStereoValue('?'));
+    }
+
+    Ok(DoubleBondStereo { atom1: atom1_1based - 1, atom2: atom2_1based - 1, parity })
+}
+
+/// Parses a single tetrahedral spec like `13-`.
+fn parse_tetrahedral_spec(spec: &str) -> Result<TetrahedralStereo, Error<u16>> {
+    let mut chars = spec.chars().peekable();
+
+    // Parse atom index (1-based)
+    let atom_1based = match try_fold_number::<u16, BaselineDigit, _>(&mut chars) {
+        Some(Ok(n)) if n > 0 => n,
+        _ => {
+            return Err(Error::InvalidStereoValue(spec.chars().next().unwrap_or('?')));
+        }
+    };
+
+    // Parse parity
+    let parity = match chars.next() {
+        Some(c) => parse_parity(c)?,
+        None => return Err(Error::InvalidStereoValue('?')),
+    };
+
+    if chars.next().is_some() {
+        return Err(Error::InvalidStereoValue('?'));
+    }
+
+    Ok(TetrahedralStereo { atom: atom_1based - 1, parity })
+}
+
+// --- DoubleBondSublayer ---
+
+impl FromStrWithContext for DoubleBondSublayer {
+    type Context<'a> = &'a InChIFormula;
+    type Input<'a> = &'a str;
+    type Idx = u16;
+
+    fn from_str_with_context(
+        input: Self::Input<'_>,
+        context: Self::Context<'_>,
+    ) -> Result<Self, Error<Self::Idx>> {
+        let s = input.strip_prefix(Self::PREFIX).ok_or(Error::WrongPrefix)?;
+
+        let mut subformulas = context.subformulas();
+        let mut components = Vec::with_capacity(context.number_of_mixtures());
+
+        for component_str in s.split(';') {
+            let digit_count = component_str.bytes().take_while(u8::is_ascii_digit).count();
+            let (reps, component_str) =
+                if digit_count > 0 && component_str.as_bytes().get(digit_count) == Some(&b'*') {
+                    component_str[..digit_count]
+                        .parse::<u32>()
+                        .ok()
+                        .map_or((1u32, component_str), |n| (n, &component_str[digit_count + 1..]))
+                } else {
+                    (1u32, component_str)
+                };
+
+            subformulas.next().ok_or(Error::FormulaAndConnectionLayerMixtureMismatch(
+                context.number_of_mixtures(),
+            ))?;
+
+            let bonds = if component_str.is_empty() {
+                Vec::new()
+            } else {
+                component_str
+                    .split(',')
+                    .map(parse_double_bond_spec)
+                    .collect::<Result<Vec<_>, _>>()?
+            };
+
+            components.push(bonds.clone());
+            for _ in 1..reps {
+                subformulas.next().ok_or(Error::FormulaAndConnectionLayerMixtureMismatch(
+                    context.number_of_mixtures(),
+                ))?;
+                components.push(bonds.clone());
+            }
+        }
+
+        if subformulas.next().is_some() {
+            return Err(Error::FormulaAndConnectionLayerMixtureMismatch(
+                context.number_of_mixtures(),
+            ));
+        }
+
+        Ok(DoubleBondSublayer { components })
     }
 }
 
-impl FromStr for DoubleBondSublayer {
-    type Err = crate::errors::Error<usize>;
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Err(Error::UnimplementedFeature("DoubleBondSublayer not implemented yet !"))
+impl PrefixFromStrWithContext for DoubleBondSublayer {}
+
+// --- TetrahedralSublayer ---
+
+impl FromStrWithContext for TetrahedralSublayer {
+    type Context<'a> = &'a InChIFormula;
+    type Input<'a> = &'a str;
+    type Idx = u16;
+
+    fn from_str_with_context(
+        input: Self::Input<'_>,
+        context: Self::Context<'_>,
+    ) -> Result<Self, Error<Self::Idx>> {
+        let s = input.strip_prefix(Self::PREFIX).ok_or(Error::WrongPrefix)?;
+
+        let mut subformulas = context.subformulas();
+        let mut components = Vec::with_capacity(context.number_of_mixtures());
+
+        for component_str in s.split(';') {
+            let digit_count = component_str.bytes().take_while(u8::is_ascii_digit).count();
+            let (reps, component_str) =
+                if digit_count > 0 && component_str.as_bytes().get(digit_count) == Some(&b'*') {
+                    component_str[..digit_count]
+                        .parse::<u32>()
+                        .ok()
+                        .map_or((1u32, component_str), |n| (n, &component_str[digit_count + 1..]))
+                } else {
+                    (1u32, component_str)
+                };
+
+            subformulas.next().ok_or(Error::FormulaAndConnectionLayerMixtureMismatch(
+                context.number_of_mixtures(),
+            ))?;
+
+            let centers = if component_str.is_empty() {
+                Vec::new()
+            } else {
+                component_str
+                    .split(',')
+                    .map(parse_tetrahedral_spec)
+                    .collect::<Result<Vec<_>, _>>()?
+            };
+
+            components.push(centers.clone());
+            for _ in 1..reps {
+                subformulas.next().ok_or(Error::FormulaAndConnectionLayerMixtureMismatch(
+                    context.number_of_mixtures(),
+                ))?;
+                components.push(centers.clone());
+            }
+        }
+
+        if subformulas.next().is_some() {
+            return Err(Error::FormulaAndConnectionLayerMixtureMismatch(
+                context.number_of_mixtures(),
+            ));
+        }
+
+        Ok(TetrahedralSublayer { components })
     }
 }
 
-impl FromStr for StereoChemistryInformationSublayer {
-    type Err = crate::errors::Error<usize>;
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Err(Error::UnimplementedFeature("StereoChemistryInformationSublayer not implemented yet !"))
+impl PrefixFromStrWithContext for TetrahedralSublayer {}
+
+// --- AlleneSublayer ---
+
+impl FromStrWithContext for AlleneSublayer {
+    type Context<'a> = ();
+    type Input<'a> = &'a str;
+    type Idx = u16;
+
+    fn from_str_with_context(
+        input: Self::Input<'_>,
+        _context: Self::Context<'_>,
+    ) -> Result<Self, Error<Self::Idx>> {
+        let s = input.strip_prefix(Self::PREFIX).ok_or(Error::WrongPrefix)?;
+
+        let mut values = Vec::new();
+        for segment in s.split('.') {
+            if segment.is_empty() {
+                values.push(None);
+            } else {
+                for c in segment.chars() {
+                    match c {
+                        '0' => values.push(Some(0)),
+                        '1' => values.push(Some(1)),
+                        _ => return Err(Error::InvalidStereoValue(c)),
+                    }
+                }
+            }
+        }
+
+        Ok(AlleneSublayer { values })
     }
 }
 
-impl FromStr for TetrahedralSublayer {
-    type Err = crate::errors::Error<usize>;
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        Err(Error::UnimplementedFeature("TetrahedralSublayer not implemented yet !"))
+impl PrefixFromStrWithContext for AlleneSublayer {}
+
+// --- StereoChemistryInformationSublayer ---
+
+impl FromStrWithContext for StereoChemistryInformationSublayer {
+    type Context<'a> = ();
+    type Input<'a> = &'a str;
+    type Idx = u16;
+
+    fn from_str_with_context(
+        input: Self::Input<'_>,
+        _context: Self::Context<'_>,
+    ) -> Result<Self, Error<Self::Idx>> {
+        let s = input.strip_prefix(Self::PREFIX).ok_or(Error::WrongPrefix)?;
+
+        let mut chars = s.chars();
+        let c = chars.next().ok_or(Error::InvalidStereoValue('s'))?;
+        if chars.next().is_some() {
+            return Err(Error::InvalidStereoValue(c));
+        }
+        match c {
+            '1'..='3' => Ok(StereoChemistryInformationSublayer { value: c as u8 - b'0' }),
+            _ => Err(Error::InvalidStereoValue(c)),
+        }
+    }
+}
+
+impl PrefixFromStrWithContext for StereoChemistryInformationSublayer {}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use molecular_formulas::InChIFormula;
+
+    use crate::{
+        errors::Error,
+        inchi::stereochemistry_layer::{
+            AlleneSublayer, DoubleBondSublayer, StereoChemistryInformationSublayer, StereoParity,
+            TetrahedralSublayer,
+        },
+        traits::parse::FromStrWithContext,
+    };
+
+    fn formula(s: &str) -> InChIFormula {
+        InChIFormula::from_str(s).expect("valid formula")
+    }
+
+    // --- /b tests ---
+
+    #[test]
+    fn test_b_single_bond_trans() {
+        let f = formula("C12H20");
+        let result = DoubleBondSublayer::from_str_with_context("b12-11+", &f).unwrap();
+        assert_eq!(result.components.len(), 1);
+        assert_eq!(result.components[0].len(), 1);
+        assert_eq!(result.components[0][0].atom1, 11);
+        assert_eq!(result.components[0][0].atom2, 10);
+        assert_eq!(result.components[0][0].parity, StereoParity::Plus);
+    }
+
+    #[test]
+    fn test_b_two_bonds() {
+        let f = formula("C17H30");
+        let result = DoubleBondSublayer::from_str_with_context("b12-11+,17-13+", &f).unwrap();
+        assert_eq!(result.components[0].len(), 2);
+        assert_eq!(result.components[0][0].atom1, 11);
+        assert_eq!(result.components[0][0].atom2, 10);
+        assert_eq!(result.components[0][0].parity, StereoParity::Plus);
+        assert_eq!(result.components[0][1].atom1, 16);
+        assert_eq!(result.components[0][1].atom2, 12);
+        assert_eq!(result.components[0][1].parity, StereoParity::Plus);
+    }
+
+    #[test]
+    fn test_b_plus_and_unknown() {
+        let f = formula("C10H16");
+        let result = DoubleBondSublayer::from_str_with_context("b6-5+,10-7?", &f).unwrap();
+        assert_eq!(result.components[0].len(), 2);
+        assert_eq!(result.components[0][0].parity, StereoParity::Plus);
+        assert_eq!(result.components[0][1].parity, StereoParity::Unknown);
+    }
+
+    #[test]
+    fn test_b_minus_parity() {
+        let f = formula("C11H20");
+        let result = DoubleBondSublayer::from_str_with_context("b11-6-", &f).unwrap();
+        assert_eq!(result.components[0][0].parity, StereoParity::Minus);
+    }
+
+    #[test]
+    fn test_b_multi_component() {
+        let f = formula("C3H6.C2H4");
+        let result = DoubleBondSublayer::from_str_with_context("b3-2+;1-2-", &f).unwrap();
+        assert_eq!(result.components.len(), 2);
+        assert_eq!(result.components[0].len(), 1);
+        assert_eq!(result.components[0][0].atom1, 2);
+        assert_eq!(result.components[0][0].atom2, 1);
+        assert_eq!(result.components[0][0].parity, StereoParity::Plus);
+        assert_eq!(result.components[1].len(), 1);
+        assert_eq!(result.components[1][0].atom1, 0);
+        assert_eq!(result.components[1][0].atom2, 1);
+        assert_eq!(result.components[1][0].parity, StereoParity::Minus);
+    }
+
+    #[test]
+    fn test_b_empty_body() {
+        let f = formula("C3H6");
+        let result = DoubleBondSublayer::from_str_with_context("b", &f).unwrap();
+        assert_eq!(result.components.len(), 1);
+        assert!(result.components[0].is_empty());
+    }
+
+    #[test]
+    fn test_b_wrong_prefix() {
+        let f = formula("C3H6");
+        let err = DoubleBondSublayer::from_str_with_context("t3-2+", &f).unwrap_err();
+        assert!(matches!(err, Error::WrongPrefix));
+    }
+
+    // --- /t tests ---
+
+    #[test]
+    fn test_t_four_centers() {
+        let f = formula("C16H30");
+        let result = TetrahedralSublayer::from_str_with_context("t13-,14-,15+,16-", &f).unwrap();
+        assert_eq!(result.components[0].len(), 4);
+        assert_eq!(result.components[0][0].atom, 12);
+        assert_eq!(result.components[0][0].parity, StereoParity::Minus);
+        assert_eq!(result.components[0][1].atom, 13);
+        assert_eq!(result.components[0][1].parity, StereoParity::Minus);
+        assert_eq!(result.components[0][2].atom, 14);
+        assert_eq!(result.components[0][2].parity, StereoParity::Plus);
+        assert_eq!(result.components[0][3].atom, 15);
+        assert_eq!(result.components[0][3].parity, StereoParity::Minus);
+    }
+
+    #[test]
+    fn test_t_two_centers() {
+        let f = formula("C5H10");
+        let result = TetrahedralSublayer::from_str_with_context("t2-,5+", &f).unwrap();
+        assert_eq!(result.components[0].len(), 2);
+        assert_eq!(result.components[0][0].atom, 1);
+        assert_eq!(result.components[0][0].parity, StereoParity::Minus);
+        assert_eq!(result.components[0][1].atom, 4);
+        assert_eq!(result.components[0][1].parity, StereoParity::Plus);
+    }
+
+    #[test]
+    fn test_t_unknown_parity() {
+        let f = formula("C6H12");
+        let result = TetrahedralSublayer::from_str_with_context("t6?", &f).unwrap();
+        assert_eq!(result.components[0].len(), 1);
+        assert_eq!(result.components[0][0].atom, 5);
+        assert_eq!(result.components[0][0].parity, StereoParity::Unknown);
+    }
+
+    #[test]
+    fn test_t_multi_component() {
+        let f = formula("C32H34N4O4.Ni");
+        let result = TetrahedralSublayer::from_str_with_context("t15-,19-;", &f).unwrap();
+        assert_eq!(result.components.len(), 2);
+        assert_eq!(result.components[0].len(), 2);
+        assert_eq!(result.components[0][0].atom, 14);
+        assert_eq!(result.components[0][0].parity, StereoParity::Minus);
+        assert_eq!(result.components[0][1].atom, 18);
+        assert_eq!(result.components[0][1].parity, StereoParity::Minus);
+        assert!(result.components[1].is_empty());
+    }
+
+    #[test]
+    fn test_t_repetition_prefix() {
+        let f = formula("2CH4");
+        let result = TetrahedralSublayer::from_str_with_context("t2*1+", &f).unwrap();
+        assert_eq!(result.components.len(), 2);
+        for comp in &result.components {
+            assert_eq!(comp.len(), 1);
+            assert_eq!(comp[0].atom, 0);
+            assert_eq!(comp[0].parity, StereoParity::Plus);
+        }
+    }
+
+    #[test]
+    fn test_t_empty_body() {
+        let f = formula("CH4");
+        let result = TetrahedralSublayer::from_str_with_context("t", &f).unwrap();
+        assert_eq!(result.components.len(), 1);
+        assert!(result.components[0].is_empty());
+    }
+
+    #[test]
+    fn test_t_wrong_prefix() {
+        let f = formula("CH4");
+        let err = TetrahedralSublayer::from_str_with_context("b3+", &f).unwrap_err();
+        assert!(matches!(err, Error::WrongPrefix));
+    }
+
+    // --- /m tests ---
+
+    #[test]
+    fn test_m_zero() {
+        let result = AlleneSublayer::from_str_with_context("m0", ()).unwrap();
+        assert_eq!(result.values, &[Some(0)]);
+    }
+
+    #[test]
+    fn test_m_one() {
+        let result = AlleneSublayer::from_str_with_context("m1", ()).unwrap();
+        assert_eq!(result.values, &[Some(1)]);
+    }
+
+    #[test]
+    fn test_m_zero_dot() {
+        let result = AlleneSublayer::from_str_with_context("m0.", ()).unwrap();
+        assert_eq!(result.values, &[Some(0), None]);
+    }
+
+    #[test]
+    fn test_m_one_dot() {
+        let result = AlleneSublayer::from_str_with_context("m1.", ()).unwrap();
+        assert_eq!(result.values, &[Some(1), None]);
+    }
+
+    #[test]
+    fn test_m_two_digits_same_group() {
+        // m00. → two components value 0 in first group, empty second group
+        let result = AlleneSublayer::from_str_with_context("m00.", ()).unwrap();
+        assert_eq!(result.values, &[Some(0), Some(0), None]);
+    }
+
+    #[test]
+    fn test_m_two_digits_no_dot() {
+        // m01 → two components: first 0, second 1
+        let result = AlleneSublayer::from_str_with_context("m01", ()).unwrap();
+        assert_eq!(result.values, &[Some(0), Some(1)]);
+    }
+
+    #[test]
+    fn test_m_empty_first_group() {
+        // m.11 → first group empty, then two components value 1
+        let result = AlleneSublayer::from_str_with_context("m.11", ()).unwrap();
+        assert_eq!(result.values, &[None, Some(1), Some(1)]);
+    }
+
+    #[test]
+    fn test_m_two_digits_trailing_dot() {
+        // m11. → two components value 1, empty third group
+        let result = AlleneSublayer::from_str_with_context("m11.", ()).unwrap();
+        assert_eq!(result.values, &[Some(1), Some(1), None]);
+    }
+
+    #[test]
+    fn test_m_wrong_prefix() {
+        let err = AlleneSublayer::from_str_with_context("s1", ()).unwrap_err();
+        assert!(matches!(err, Error::WrongPrefix));
+    }
+
+    #[test]
+    fn test_m_invalid_value() {
+        let err = AlleneSublayer::from_str_with_context("m2", ()).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue('2')));
+    }
+
+    // --- /s tests ---
+
+    #[test]
+    fn test_s_absolute() {
+        let result = StereoChemistryInformationSublayer::from_str_with_context("s1", ()).unwrap();
+        assert_eq!(result.value, 1);
+    }
+
+    #[test]
+    fn test_s_relative() {
+        let result = StereoChemistryInformationSublayer::from_str_with_context("s2", ()).unwrap();
+        assert_eq!(result.value, 2);
+    }
+
+    #[test]
+    fn test_s_racemic() {
+        let result = StereoChemistryInformationSublayer::from_str_with_context("s3", ()).unwrap();
+        assert_eq!(result.value, 3);
+    }
+
+    #[test]
+    fn test_s_wrong_prefix() {
+        let err = StereoChemistryInformationSublayer::from_str_with_context("m1", ()).unwrap_err();
+        assert!(matches!(err, Error::WrongPrefix));
+    }
+
+    #[test]
+    fn test_s_invalid_value() {
+        let err = StereoChemistryInformationSublayer::from_str_with_context("s0", ()).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue('0')));
+    }
+
+    #[test]
+    fn test_s_empty_body() {
+        let err = StereoChemistryInformationSublayer::from_str_with_context("s", ()).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue('s')));
+    }
+
+    #[test]
+    fn test_s_value_4_rejected() {
+        let err = StereoChemistryInformationSublayer::from_str_with_context("s4", ()).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue('4')));
+    }
+
+    #[test]
+    fn test_s_multi_digit_rejected() {
+        // "s12" → first char '1' consumed, then '2' remains → error
+        let err = StereoChemistryInformationSublayer::from_str_with_context("s12", ()).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue('1')));
+    }
+
+    // --- /b error cases ---
+
+    #[test]
+    fn test_b_missing_parity() {
+        // "b12-11" → no parity char after second atom
+        let f = formula("C12H20");
+        let err = DoubleBondSublayer::from_str_with_context("b12-11", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue(_)));
+    }
+
+    #[test]
+    fn test_b_missing_separator() {
+        // "b1211+" → no '-' between atoms
+        let f = formula("C12H20");
+        let err = DoubleBondSublayer::from_str_with_context("b1211+", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue(_)));
+    }
+
+    #[test]
+    fn test_b_zero_atom_index() {
+        // "b0-1+" → atom1 is 0, invalid
+        let f = formula("C3H6");
+        let err = DoubleBondSublayer::from_str_with_context("b0-1+", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue(_)));
+    }
+
+    #[test]
+    fn test_b_invalid_parity_char() {
+        // "b1-2x" → 'x' is not a valid parity
+        let f = formula("C3H6");
+        let err = DoubleBondSublayer::from_str_with_context("b1-2x", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue('x')));
+    }
+
+    #[test]
+    fn test_b_component_mismatch() {
+        // Two components in /b but single component formula
+        let f = formula("C3H6");
+        let err = DoubleBondSublayer::from_str_with_context("b1-2+;1-2-", &f).unwrap_err();
+        assert!(matches!(err, Error::FormulaAndConnectionLayerMixtureMismatch(_)));
+    }
+
+    #[test]
+    fn test_b_trailing_comma() {
+        // "b1-2+," → trailing comma produces empty spec
+        let f = formula("C3H6");
+        let err = DoubleBondSublayer::from_str_with_context("b1-2+,", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue(_)));
+    }
+
+    // --- /t error cases ---
+
+    #[test]
+    fn test_t_missing_parity() {
+        // "t13" → no parity char after atom
+        let f = formula("C16H30");
+        let err = TetrahedralSublayer::from_str_with_context("t13", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue(_)));
+    }
+
+    #[test]
+    fn test_t_zero_atom_index() {
+        // "t0+" → atom index is 0, invalid
+        let f = formula("CH4");
+        let err = TetrahedralSublayer::from_str_with_context("t0+", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue(_)));
+    }
+
+    #[test]
+    fn test_t_invalid_parity_char() {
+        // "t1x" → 'x' is not a valid parity
+        let f = formula("CH4");
+        let err = TetrahedralSublayer::from_str_with_context("t1x", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue('x')));
+    }
+
+    #[test]
+    fn test_t_trailing_comma() {
+        // "t1+," → trailing comma produces empty spec
+        let f = formula("CH4");
+        let err = TetrahedralSublayer::from_str_with_context("t1+,", &f).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue(_)));
+    }
+
+    #[test]
+    fn test_t_component_mismatch() {
+        // Two components in /t but single component formula
+        let f = formula("CH4");
+        let err = TetrahedralSublayer::from_str_with_context("t1+;2-", &f).unwrap_err();
+        assert!(matches!(err, Error::FormulaAndConnectionLayerMixtureMismatch(_)));
+    }
+
+    // --- /m edge cases ---
+
+    #[test]
+    fn test_m_multiple_dots() {
+        // m0..1 → three groups: first has '0', second empty, third has '1'
+        let result = AlleneSublayer::from_str_with_context("m0..1", ()).unwrap();
+        assert_eq!(result.values, &[Some(0), None, Some(1)]);
+    }
+
+    #[test]
+    fn test_m_all_empty() {
+        // m.. → two dots = three groups all empty
+        let result = AlleneSublayer::from_str_with_context("m..", ()).unwrap();
+        assert_eq!(result.values, &[None, None, None]);
+    }
+
+    #[test]
+    fn test_m_letter_rejected() {
+        let err = AlleneSublayer::from_str_with_context("ma", ()).unwrap_err();
+        assert!(matches!(err, Error::InvalidStereoValue('a')));
+    }
+
+    // --- try_build_layer tests ---
+
+    use crate::traits::parse::PrefixFromStrWithContext;
+
+    #[test]
+    fn test_b_try_build_layer_not_present() {
+        let f = formula("CH4");
+        let mut input = "t1+";
+        let result = DoubleBondSublayer::try_build_layer(&mut input, &f).unwrap();
+        assert!(result.is_none());
+        assert_eq!(input, "t1+"); // unchanged
+    }
+
+    #[test]
+    fn test_t_try_build_layer_consumes_segment() {
+        let f = formula("CH4");
+        let mut input = "t1+/m0/s1";
+        let result = TetrahedralSublayer::try_build_layer(&mut input, &f).unwrap().unwrap();
+        assert_eq!(result.components[0].len(), 1);
+        assert_eq!(input, "m0/s1"); // /t consumed
+    }
+
+    #[test]
+    fn test_m_try_build_layer_consumes_segment() {
+        let mut input = "m0/s1";
+        let result = AlleneSublayer::try_build_layer(&mut input, ()).unwrap().unwrap();
+        assert_eq!(result.values, &[Some(0)]);
+        assert_eq!(input, "s1"); // /m consumed
+    }
+
+    #[test]
+    fn test_s_try_build_layer_at_end() {
+        let mut input = "s1";
+        let result =
+            StereoChemistryInformationSublayer::try_build_layer(&mut input, ()).unwrap().unwrap();
+        assert_eq!(result.value, 1);
+        assert_eq!(input, ""); // fully consumed
+    }
+
+    #[test]
+    fn test_b_try_build_layer_at_end() {
+        let f = formula("C3H6");
+        let mut input = "b1-2+";
+        let result = DoubleBondSublayer::try_build_layer(&mut input, &f).unwrap().unwrap();
+        assert_eq!(result.components[0].len(), 1);
+        assert_eq!(input, ""); // fully consumed
     }
 }

--- a/src/inchi.rs
+++ b/src/inchi.rs
@@ -11,7 +11,7 @@ pub use fixed_hydrogen::FixedHydrogenLayer;
 pub use isotope_layer::IsotopeLayer;
 pub use main_layer::MainLayer;
 pub use reconnected_layer::ReconnectedLayer;
-pub(crate) use stereochemistry_layer::StereochemistryLayer;
+pub use stereochemistry_layer::StereochemistryLayer;
 
 use crate::{
     inchi::{charge_layer::ChargeSubLayer, proton_layer::ProtonSublayer},
@@ -29,6 +29,12 @@ impl<V: Version> InChI<V> {
     #[must_use]
     pub fn proton_count(&self) -> Option<i16> {
         self.proton.as_ref().map(|p| p.proton_count)
+    }
+
+    /// Returns the stereochemistry layer, if present.
+    #[must_use]
+    pub fn stereochemistry(&self) -> Option<&StereochemistryLayer> {
+        self.stereochemistry.as_ref()
     }
 
     /// Returns the isotope layer, if present.

--- a/src/inchi.rs
+++ b/src/inchi.rs
@@ -19,6 +19,14 @@ use crate::{
 };
 
 impl<V: Version> InChI<V> {
+    /// Returns the main layer (formula, connections, hydrogens), if present.
+    ///
+    /// Proton-only InChIs (e.g. `InChI=1S/p+1`) have no main layer.
+    #[must_use]
+    pub fn main_layer(&self) -> Option<&MainLayer> {
+        self.main_layer.as_ref()
+    }
+
     /// Returns the per-component charges from the `/q` layer, if present.
     #[must_use]
     pub fn charges(&self) -> Option<&[i16]> {
@@ -47,7 +55,7 @@ impl<V: Version> InChI<V> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// The InChI structure
 pub struct InChI<V: Version = crate::version::StandardVersion1_07_4> {
-    pub(crate) main_layer: MainLayer,
+    pub(crate) main_layer: Option<MainLayer>,
     pub(crate) charge: Option<ChargeSubLayer>,
     pub(crate) proton: Option<ProtonSublayer>,
     pub(crate) stereochemistry: Option<StereochemistryLayer>,

--- a/src/inchi/stereochemistry_layer.rs
+++ b/src/inchi/stereochemistry_layer.rs
@@ -1,31 +1,172 @@
 //! Module for the stereochemistry layer of an InChI.
+
+use alloc::vec::Vec;
+
 use crate::traits::prefix::Prefix;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// The stereochemistry layer of an InChI.
-pub(crate) struct StereochemistryLayer;
+/// Stereo parity designation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StereoParity {
+    /// `+` parity (trans/E for double bonds, positive for tetrahedral).
+    Plus,
+    /// `-` parity (cis/Z for double bonds, negative for tetrahedral).
+    Minus,
+    /// `?` parity (unknown).
+    Unknown,
+}
 
-#[expect(dead_code, reason = "stereo sublayer parsing is not implemented yet")]
-pub(crate) struct DoubleBondSublayer;
-#[expect(dead_code, reason = "stereo sublayer parsing is not implemented yet")]
-pub(crate) struct TetrahedralSublayer;
-#[expect(dead_code, reason = "stereo sublayer parsing is not implemented yet")]
-pub(crate) struct AlleneSublayer;
-#[expect(dead_code, reason = "stereo sublayer parsing is not implemented yet")]
-pub(crate) struct StereoChemistryInformationSublayer;
+/// A double bond stereo specification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoubleBondStereo {
+    pub(crate) atom1: u16,
+    pub(crate) atom2: u16,
+    pub(crate) parity: StereoParity,
+}
+
+impl DoubleBondStereo {
+    /// Returns the first atom index (0-based).
+    #[must_use]
+    pub fn atom1(&self) -> u16 {
+        self.atom1
+    }
+
+    /// Returns the second atom index (0-based).
+    #[must_use]
+    pub fn atom2(&self) -> u16 {
+        self.atom2
+    }
+
+    /// Returns the parity.
+    #[must_use]
+    pub fn parity(&self) -> StereoParity {
+        self.parity
+    }
+}
+
+/// Double bond stereo sublayer: per-component bond specs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoubleBondSublayer {
+    pub(crate) components: Vec<Vec<DoubleBondStereo>>,
+}
+
+impl DoubleBondSublayer {
+    /// Returns the per-component double bond stereo specifications.
+    #[must_use]
+    pub fn components(&self) -> &[Vec<DoubleBondStereo>] {
+        &self.components
+    }
+}
 
 impl Prefix for DoubleBondSublayer {
     const PREFIX: char = 'b';
+}
+
+/// A tetrahedral stereo specification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TetrahedralStereo {
+    pub(crate) atom: u16,
+    pub(crate) parity: StereoParity,
+}
+
+impl TetrahedralStereo {
+    /// Returns the atom index (0-based).
+    #[must_use]
+    pub fn atom(&self) -> u16 {
+        self.atom
+    }
+
+    /// Returns the parity.
+    #[must_use]
+    pub fn parity(&self) -> StereoParity {
+        self.parity
+    }
+}
+
+/// Tetrahedral stereo sublayer: per-component center specs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TetrahedralSublayer {
+    pub(crate) components: Vec<Vec<TetrahedralStereo>>,
+}
+
+impl TetrahedralSublayer {
+    /// Returns the per-component tetrahedral stereo specifications.
+    #[must_use]
+    pub fn components(&self) -> &[Vec<TetrahedralStereo>] {
+        &self.components
+    }
 }
 
 impl Prefix for TetrahedralSublayer {
     const PREFIX: char = 't';
 }
 
+/// Allene/mirror sublayer: per-component 0/1 values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlleneSublayer {
+    pub(crate) values: Vec<Option<u8>>,
+}
+
+impl AlleneSublayer {
+    /// Returns the per-component values.
+    #[must_use]
+    pub fn values(&self) -> &[Option<u8>] {
+        &self.values
+    }
+}
+
 impl Prefix for AlleneSublayer {
     const PREFIX: char = 'm';
 }
 
+/// Stereo type sublayer: global value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StereoChemistryInformationSublayer {
+    pub(crate) value: u8,
+}
+
+impl StereoChemistryInformationSublayer {
+    /// Returns the stereo type value (1 = absolute, 2 = relative, 3 = racemic).
+    #[must_use]
+    pub fn value(&self) -> u8 {
+        self.value
+    }
+}
+
 impl Prefix for StereoChemistryInformationSublayer {
     const PREFIX: char = 's';
+}
+
+/// Composite stereochemistry layer holding all sublayers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StereochemistryLayer {
+    pub(crate) double_bond: Option<DoubleBondSublayer>,
+    pub(crate) tetrahedral: Option<TetrahedralSublayer>,
+    pub(crate) allene: Option<AlleneSublayer>,
+    pub(crate) stereo_info: Option<StereoChemistryInformationSublayer>,
+}
+
+impl StereochemistryLayer {
+    /// Returns the double bond stereo sublayer, if present.
+    #[must_use]
+    pub fn double_bond(&self) -> Option<&DoubleBondSublayer> {
+        self.double_bond.as_ref()
+    }
+
+    /// Returns the tetrahedral stereo sublayer, if present.
+    #[must_use]
+    pub fn tetrahedral(&self) -> Option<&TetrahedralSublayer> {
+        self.tetrahedral.as_ref()
+    }
+
+    /// Returns the allene/mirror sublayer, if present.
+    #[must_use]
+    pub fn allene(&self) -> Option<&AlleneSublayer> {
+        self.allene.as_ref()
+    }
+
+    /// Returns the stereo type sublayer, if present.
+    #[must_use]
+    pub fn stereo_info(&self) -> Option<&StereoChemistryInformationSublayer> {
+        self.stereo_info.as_ref()
+    }
 }

--- a/tests/test_inchi.rs
+++ b/tests/test_inchi.rs
@@ -1,9 +1,6 @@
 //! InChI parsing integration tests.
 
-use inchi_parser::{
-    errors::Error,
-    inchi::{InChI, stereochemistry_layer::StereoParity},
-};
+use inchi_parser::inchi::{InChI, stereochemistry_layer::StereoParity};
 
 const INCHI_TEST: &[&str] = &[
     "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
@@ -133,27 +130,11 @@ const INCHI_TEST: &[&str] = &[
 
 #[test]
 fn test_inchi_parsing() {
-    let mut parsed = 0usize;
-    let mut proton_only = 0usize;
     for (i, &inchi_str) in INCHI_TEST.iter().enumerate() {
-        match inchi_str.parse::<InChI>() {
-            Ok(_) => {
-                parsed += 1;
-            }
-            Err(Error::UnimplementedFeature(msg)) if msg.contains("Proton-only") => {
-                // Proton-only InChIs (e.g. "InChI=1S/p+1") are expected to be
-                // unimplemented for now.
-                proton_only += 1;
-            }
-            Err(e) => {
-                panic!("{i}) Failed to parse InChI {inchi_str}: {e:?}");
-            }
+        if let Err(e) = inchi_str.parse::<InChI>() {
+            panic!("{i}) Failed to parse InChI {inchi_str}: {e:?}");
         }
     }
-    println!(
-        "Parsed {parsed}/{} InChI strings ({proton_only} proton-only skipped).",
-        INCHI_TEST.len()
-    );
 }
 
 #[test]
@@ -585,4 +566,69 @@ fn test_stereo_insulin_many_centers() {
     let last = tet.components()[0].last().unwrap();
     assert_eq!(last.atom(), 215); // t216- → 0-based 215
     assert_eq!(last.parity(), StereoParity::Minus);
+}
+
+// --- Proton-only InChI tests ---
+
+#[test]
+fn test_proton_only_simple() {
+    let inchi: InChI = "InChI=1S/p+1".parse().unwrap();
+    assert!(inchi.main_layer().is_none());
+    assert_eq!(inchi.proton_count(), Some(1));
+    assert!(inchi.isotope().is_none());
+    assert!(inchi.charges().is_none());
+    assert!(inchi.stereochemistry().is_none());
+}
+
+#[test]
+fn test_proton_only_count_3() {
+    let inchi: InChI = "InChI=1S/p+3".parse().unwrap();
+    assert!(inchi.main_layer().is_none());
+    assert_eq!(inchi.proton_count(), Some(3));
+}
+
+#[test]
+fn test_proton_only_isotope_deuterium() {
+    let inchi: InChI = "InChI=1S/p+1/i/hD".parse().unwrap();
+    assert!(inchi.main_layer().is_none());
+    assert_eq!(inchi.proton_count(), Some(1));
+    let iso = inchi.isotope().expect("isotope layer should be present");
+    assert_eq!(iso.components().len(), 1);
+    assert!(iso.components()[0].atoms().is_empty());
+    assert_eq!(iso.components()[0].hydrogens().len(), 1);
+    assert_eq!(
+        iso.components()[0].hydrogens()[0].isotope(),
+        elements_rs::isotopes::HydrogenIsotope::D
+    );
+    assert_eq!(iso.components()[0].hydrogens()[0].count(), 1);
+}
+
+#[test]
+fn test_proton_only_isotope_tritium() {
+    let inchi: InChI = "InChI=1S/p+1/i/hT".parse().unwrap();
+    assert!(inchi.main_layer().is_none());
+    assert_eq!(inchi.proton_count(), Some(1));
+    let iso = inchi.isotope().expect("isotope layer should be present");
+    assert_eq!(
+        iso.components()[0].hydrogens()[0].isotope(),
+        elements_rs::isotopes::HydrogenIsotope::T
+    );
+}
+
+#[test]
+fn test_proton_only_isotope_protium() {
+    let inchi: InChI = "InChI=1S/p+1/i/hH".parse().unwrap();
+    assert!(inchi.main_layer().is_none());
+    assert_eq!(inchi.proton_count(), Some(1));
+    let iso = inchi.isotope().expect("isotope layer should be present");
+    assert_eq!(
+        iso.components()[0].hydrogens()[0].isotope(),
+        elements_rs::isotopes::HydrogenIsotope::H1
+    );
+}
+
+#[test]
+fn test_normal_inchi_has_main_layer() {
+    let inchi: InChI = "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3".parse().unwrap();
+    assert!(inchi.main_layer().is_some());
 }

--- a/tests/test_inchi.rs
+++ b/tests/test_inchi.rs
@@ -1,6 +1,9 @@
 //! InChI parsing integration tests.
 
-use inchi_parser::{errors::Error, inchi::InChI};
+use inchi_parser::{
+    errors::Error,
+    inchi::{InChI, stereochemistry_layer::StereoParity},
+};
 
 const INCHI_TEST: &[&str] = &[
     "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3",
@@ -272,4 +275,314 @@ fn test_isotope_atom_level_deuterium() {
     assert_eq!(atom.mass_shift(), None);
     assert_eq!(atom.hydrogen_isotopes().len(), 1);
     assert_eq!(atom.hydrogen_isotopes()[0].isotope(), elements_rs::isotopes::HydrogenIsotope::D);
+}
+
+// --- Stereochemistry layer integration tests ---
+
+#[test]
+fn test_stereo_tetrahedral_ascorbic_acid() {
+    // Ascorbic acid: /t2-,5+/m0/s1
+    let inchi: InChI = "InChI=1S/C6H8O6/c7-1-2(8)5-3(9)4(10)6(11)12-5/h2,5,7-10H,1H2/t2-,5+/m0/s1"
+        .parse()
+        .unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    assert!(stereo.double_bond().is_none());
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    assert_eq!(tet.components().len(), 1);
+    assert_eq!(tet.components()[0].len(), 2);
+    assert_eq!(tet.components()[0][0].atom(), 1);
+    assert_eq!(tet.components()[0][0].parity(), StereoParity::Minus);
+    assert_eq!(tet.components()[0][1].atom(), 4);
+    assert_eq!(tet.components()[0][1].parity(), StereoParity::Plus);
+    let allene = stereo.allene().expect("allene sublayer should be present");
+    assert_eq!(allene.values(), &[Some(0)]);
+    let info = stereo.stereo_info().expect("stereo info sublayer should be present");
+    assert_eq!(info.value(), 1);
+}
+
+#[test]
+fn test_stereo_double_bond() {
+    // Retinoic acid derivative: /b20-9+
+    let inchi: InChI = "InChI=1S/C30H46O3/c1-19(8-7-9-20(2)25(32)33)21-12-14-28(6)23-11-10-22-26(3,4)24(31)13-15-29(22)18-30(23,29)17-16-27(21,28)5/h9,19,21-23H,7-8,10-18H2,1-6H3,(H,32,33)/b20-9+".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components().len(), 1);
+    assert_eq!(db.components()[0].len(), 1);
+    assert_eq!(db.components()[0][0].atom1(), 19);
+    assert_eq!(db.components()[0][0].atom2(), 8);
+    assert_eq!(db.components()[0][0].parity(), StereoParity::Plus);
+}
+
+#[test]
+fn test_stereo_multi_component_nickel_porphyrin() {
+    // Ni porphyrin: /t15-,19-;/m0./s1
+    let inchi: InChI = INCHI_TEST[4].parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    assert_eq!(tet.components().len(), 2);
+    assert_eq!(tet.components()[0].len(), 2);
+    assert_eq!(tet.components()[0][0].atom(), 14);
+    assert_eq!(tet.components()[0][0].parity(), StereoParity::Minus);
+    assert_eq!(tet.components()[0][1].atom(), 18);
+    assert_eq!(tet.components()[0][1].parity(), StereoParity::Minus);
+    assert!(tet.components()[1].is_empty());
+    let allene = stereo.allene().expect("allene sublayer should be present");
+    assert_eq!(allene.values(), &[Some(0), None]);
+}
+
+#[test]
+fn test_stereo_unknown_parity() {
+    // InChI with ? parity: /t6?
+    let inchi: InChI =
+        "InChI=1S/C6H12O6/c7-1-2(8)5-3(9)4(10)6(11)12-5/h2-11H,1H2/t2-,3+,4+,5-,6?/m1/s1"
+            .parse()
+            .unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    // Last center has ? parity
+    let last = tet.components()[0].last().unwrap();
+    assert_eq!(last.atom(), 5);
+    assert_eq!(last.parity(), StereoParity::Unknown);
+}
+
+#[test]
+fn test_no_stereo_layer() {
+    // Plain ethanol has no stereo
+    let inchi: InChI = "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3".parse().unwrap();
+    assert!(inchi.stereochemistry().is_none());
+}
+
+#[test]
+fn test_stereo_double_bond_minus() {
+    // /b11-6- → cis double bond
+    let inchi: InChI = "InChI=1S/C15H22O2/c1-10(2)13-9-14(16)12(4)7-5-6-11(3)8-15(13)17/h6,12H,5,7-9H2,1-4H3/b11-6-".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components()[0][0].parity(), StereoParity::Minus);
+}
+
+#[test]
+fn test_stereo_m_multi_digit_groups() {
+    // m00. → two components value 0 in first formula group, empty second
+    let inchi: InChI = "InChI=1S/2C20H24N2O2.H2O4S/c2*1-3-13-12-22-9-7-14(13)10-19(22)20(23)16-6-8-21-18-5-4-15(24-2)11-17(16)18;1-5(2,3)4/h2*3-6,8,11,13-14,19-20,23H,1,7,9-10,12H2,2H3;(H2,1,2,3,4)/t2*13-,14?,19+,20-;/m00./s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let allene = stereo.allene().expect("allene sublayer should be present");
+    assert_eq!(allene.values(), &[Some(0), Some(0), None]);
+}
+
+#[test]
+fn test_stereo_m_different_digits() {
+    // m01 → two components: first 0, second 1
+    let inchi: InChI = "InChI=1S/C9H13NO3.C4H6O6/c1-10-5-9(13)6-2-3-7(11)8(12)4-6;5-1(3(7)8)2(6)4(9)10/h2-4,9-13H,5H2,1H3;1-2,5-6H,(H,7,8)(H,9,10)/t9-;1-,2-/m01/s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let allene = stereo.allene().expect("allene sublayer should be present");
+    assert_eq!(allene.values(), &[Some(0), Some(1)]);
+}
+
+#[test]
+fn test_stereo_m_empty_first_group() {
+    // m.11 → first formula group empty, then two components value 1
+    let inchi: InChI = "InChI=1S/C15H32N2.2C4H6O6/c1-16(12-6-7-13-16)10-4-3-5-11-17(2)14-8-9-15-17;2*5-1(3(7)8)2(6)4(9)10/h3-15H2,1-2H3;2*1-2,5-6H,(H,7,8)(H,9,10)/q+2;;/p-2/t;2*1-,2-/m.11/s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let allene = stereo.allene().expect("allene sublayer should be present");
+    assert_eq!(allene.values(), &[None, Some(1), Some(1)]);
+}
+
+// --- Corner case: /b without /t, /m, /s ---
+
+#[test]
+fn test_stereo_b_only_no_t_m_s() {
+    // /b20-9+ with nothing following — double bond stereo only
+    let inchi: InChI = "InChI=1S/C30H46O3/c1-19(8-7-9-20(2)25(32)33)21-12-14-28(6)23-11-10-22-26(3,4)24(31)13-15-29(22)18-30(23,29)17-16-27(21,28)5/h9,19,21-23H,7-8,10-18H2,1-6H3,(H,32,33)/b20-9+".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components().len(), 1);
+    assert_eq!(db.components()[0].len(), 1);
+    assert_eq!(db.components()[0][0].atom1(), 19);
+    assert_eq!(db.components()[0][0].atom2(), 8);
+    assert_eq!(db.components()[0][0].parity(), StereoParity::Plus);
+    // No /t, /m, /s
+    assert!(stereo.tetrahedral().is_none());
+    assert!(stereo.allene().is_none());
+    assert!(stereo.stereo_info().is_none());
+}
+
+#[test]
+fn test_stereo_b_only_many_bonds() {
+    // 6 double bonds, no /t/m/s
+    let inchi: InChI = "InChI=1S/C20H20O2/c1-2-3-4-5-6-7-8-13-18-14-9-10-15-19(18)16-11-12-17-20(21)22/h2-17H,1H3,(H,21,22)/b3-2+,5-4+,7-6+,13-8+,16-11+,17-12+".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components()[0].len(), 6);
+    // All bonds should be Plus
+    for bond in &db.components()[0] {
+        assert_eq!(bond.parity(), StereoParity::Plus);
+    }
+    assert!(stereo.tetrahedral().is_none());
+    assert!(stereo.allene().is_none());
+    assert!(stereo.stereo_info().is_none());
+}
+
+// --- Corner case: /b with ? parity ---
+
+#[test]
+fn test_stereo_b_unknown_parity() {
+    // /b6-5+,10-7? → second bond has unknown parity; also /b10-7? in spec
+    let inchi: InChI = "InChI=1S/C15H20O4/c1-10(7-13(17)18)5-6-15(19)11(2)8-12(16)9-14(15,3)4/h5-8,19H,9H2,1-4H3,(H,17,18)/b6-5+,10-7?/t15-/m1/s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components()[0].len(), 2);
+    assert_eq!(db.components()[0][0].parity(), StereoParity::Plus);
+    assert_eq!(db.components()[0][1].parity(), StereoParity::Unknown);
+}
+
+// --- Corner case: /b and /t together ---
+
+#[test]
+fn test_stereo_b_and_t_together() {
+    // Both double bond and tetrahedral stereo: /b50-44+/t47-,...,62+/m0/s1
+    let inchi: InChI = "InChI=1S/C62H116O16S/c1-7-9-11-13-15-17-19-21-22-23-24-25-26-27-29-30-32-34-36-38-40-47(3)42-48(4)43-49(5)44-50(6)60(69)76-57-55(67)52(46-64)74-62(77-61-58(78-79(70,71)72)56(68)54(66)51(45-63)73-61)59(57)75-53(65)41-39-37-35-33-31-28-20-18-16-14-12-10-8-2/h44,47-49,51-52,54-59,61-64,66-68H,7-43,45-46H2,1-6H3,(H,70,71,72)/b50-44+/t47-,48-,49-,51+,52+,54+,55+,56-,57-,58+,59+,61+,62+/m0/s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components()[0].len(), 1);
+    assert_eq!(db.components()[0][0].atom1(), 49);
+    assert_eq!(db.components()[0][0].atom2(), 43);
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    assert_eq!(tet.components()[0].len(), 13);
+    assert_eq!(stereo.stereo_info().unwrap().value(), 1);
+}
+
+// --- Corner case: multi-component /t with leading ; (empty first component)
+// ---
+
+#[test]
+fn test_stereo_t_leading_semicolon() {
+    // /t;2*1-,2- → first component has no stereo, second two components via 2*
+    // prefix
+    let inchi: InChI = "InChI=1S/C15H32N2.2C4H6O6/c1-16(12-6-7-13-16)10-4-3-5-11-17(2)14-8-9-15-17;2*5-1(3(7)8)2(6)4(9)10/h3-15H2,1-2H3;2*1-2,5-6H,(H,7,8)(H,9,10)/q+2;;/p-2/t;2*1-,2-/m.11/s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    assert_eq!(tet.components().len(), 3);
+    assert!(tet.components()[0].is_empty()); // first component empty
+    assert_eq!(tet.components()[1].len(), 2); // second has 2 centers
+    assert_eq!(tet.components()[2].len(), 2); // third (repeated) has 2 centers
+    assert_eq!(tet.components()[1][0].atom(), 0);
+    assert_eq!(tet.components()[1][0].parity(), StereoParity::Minus);
+}
+
+// --- Corner case: /t with n* repetition prefix ---
+
+#[test]
+fn test_stereo_t_repetition_prefix() {
+    // /t2*13-,14?,19+,20- → 2 identical components with 4 centers each
+    let inchi: InChI = "InChI=1S/2C20H24N2O2.H2O4S/c2*1-3-13-12-22-9-7-14(13)10-19(22)20(23)16-6-8-21-18-5-4-15(24-2)11-17(16)18;1-5(2,3)4/h2*3-6,8,11,13-14,19-20,23H,1,7,9-10,12H2,2H3;(H2,1,2,3,4)/t2*13-,14?,19+,20-;/m00./s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    assert_eq!(tet.components().len(), 3);
+    // First two components should be identical (2* prefix)
+    assert_eq!(tet.components()[0], tet.components()[1]);
+    assert_eq!(tet.components()[0].len(), 4);
+    assert_eq!(tet.components()[0][0].atom(), 12);
+    assert_eq!(tet.components()[0][0].parity(), StereoParity::Minus);
+    assert_eq!(tet.components()[0][1].atom(), 13);
+    assert_eq!(tet.components()[0][1].parity(), StereoParity::Unknown);
+    assert_eq!(tet.components()[0][2].atom(), 18);
+    assert_eq!(tet.components()[0][2].parity(), StereoParity::Plus);
+    assert_eq!(tet.components()[0][3].atom(), 19);
+    assert_eq!(tet.components()[0][3].parity(), StereoParity::Minus);
+    // Third component (H2O4S) has no stereo
+    assert!(tet.components()[2].is_empty());
+}
+
+// --- Corner case: /t with all ? parities ---
+
+#[test]
+fn test_stereo_t_all_unknown() {
+    // /t17?,18? → all unknown parities (custom minimal test)
+    // Using a real InChI that has some ? parities: /t3-/m0/s1 with unknown in /b
+    // Actually test a real InChI where /t has a mix including ?
+    let inchi: InChI = "InChI=1S/C21H36O5/c1-16(22)14-12-10-8-6-4-3-5-7-9-11-13-15-18-19(20(23)24)17(2)21(25)26-18/h17-19H,3-15H2,1-2H3,(H,23,24)/t17?,18-,19?/m1/s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    assert_eq!(tet.components()[0].len(), 3);
+    assert_eq!(tet.components()[0][0].parity(), StereoParity::Unknown);
+    assert_eq!(tet.components()[0][1].parity(), StereoParity::Minus);
+    assert_eq!(tet.components()[0][2].parity(), StereoParity::Unknown);
+}
+
+// --- Corner case: /b with large atom indices ---
+
+#[test]
+fn test_stereo_b_large_indices() {
+    // /b43-24+,...,50-40+ → indices up to 50
+    let inchi: InChI = "InChI=1S/C56H80O2/c1-42(2)22-14-23-43(3)24-15-25-44(4)26-16-27-45(5)28-17-29-46(6)30-18-31-47(7)32-19-33-48(8)34-20-35-49(9)36-21-37-50(10)40-41-52-51(11)55(57)53-38-12-13-39-54(53)56(52)58/h12-13,22,24,26,28,30,32,34,36,38-40H,14-21,23,25,27,29,31,33,35,37,41H2,1-11H3/b43-24+,44-26+,45-28+,46-30+,47-32+,48-34+,49-36+,50-40+".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components()[0].len(), 8);
+    // Last bond: atoms 50→49, 40→39 (0-based)
+    let last = db.components()[0].last().unwrap();
+    assert_eq!(last.atom1(), 49);
+    assert_eq!(last.atom2(), 39);
+    assert_eq!(last.parity(), StereoParity::Plus);
+}
+
+// --- Corner case: /b with mixed parities including - ---
+
+#[test]
+fn test_stereo_b_mixed_parities() {
+    // /b20-11?,24-12- → unknown and minus in /b
+    let inchi: InChI = "InChI=1S/C19H22N8O6S2/c1-33-24-12(10-8-35-19(21)22-10)15(29)23-13-16(30)27-14(18(31)32)9(7-34-17(13)27)6-25-3-2-11(20)26(25)4-5-28/h2-3,8,13,17,20,28H,4-7H2,1H3,(H2,21,22)(H,23,29)(H,31,32)/b20-11?,24-12-/t13-,17-/m1/s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components()[0].len(), 2);
+    assert_eq!(db.components()[0][0].parity(), StereoParity::Unknown);
+    assert_eq!(db.components()[0][1].parity(), StereoParity::Minus);
+    // Also has /t
+    let tet = stereo.tetrahedral().unwrap();
+    assert_eq!(tet.components()[0].len(), 2);
+}
+
+// --- Corner case: single stereo center ---
+
+#[test]
+fn test_stereo_single_center() {
+    // /t12-/m0/s1 → single tetrahedral center
+    let inchi: InChI = "InChI=1S/C19H19NO4/c1-20-6-5-11-8-14-19(24-9-23-14)17-15(11)12(20)7-10-3-4-13(22-2)18(21)16(10)17/h3-4,8,12,21H,5-7,9H2,1-2H3/t12-/m0/s1".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    assert_eq!(tet.components()[0].len(), 1);
+    assert_eq!(tet.components()[0][0].atom(), 11);
+    assert_eq!(tet.components()[0][0].parity(), StereoParity::Minus);
+}
+
+// --- Corner case: /b with both + and - on same molecule ---
+
+#[test]
+fn test_stereo_b_plus_and_minus_together() {
+    // /b10-9+,12-11+ → two trans bonds in same molecule
+    let inchi: InChI = "InChI=1S/C19H32O3/c1-3-4-12-15-18(20)16-13-10-8-6-5-7-9-11-14-17-19(21)22-2/h8,10,13,16H,3-7,9,11-12,14-15,17H2,1-2H3/b10-8+,16-13+".parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let db = stereo.double_bond().expect("double bond sublayer should be present");
+    assert_eq!(db.components()[0].len(), 2);
+    assert_eq!(db.components()[0][0].parity(), StereoParity::Plus);
+    assert_eq!(db.components()[0][1].parity(), StereoParity::Plus);
+    // No /t, /m, /s
+    assert!(stereo.tetrahedral().is_none());
+}
+
+// --- Corner case: insulin (very large /t with many centers) ---
+
+#[test]
+fn test_stereo_insulin_many_centers() {
+    // Insulin has 53 tetrahedral centers
+    let inchi: InChI = INCHI_TEST[10].parse().unwrap();
+    let stereo = inchi.stereochemistry().expect("stereo layer should be present");
+    let tet = stereo.tetrahedral().expect("tetrahedral sublayer should be present");
+    assert_eq!(tet.components()[0].len(), 53);
+    // Verify first and last
+    assert_eq!(tet.components()[0][0].atom(), 136); // t137- → 0-based 136
+    assert_eq!(tet.components()[0][0].parity(), StereoParity::Minus);
+    let last = tet.components()[0].last().unwrap();
+    assert_eq!(last.atom(), 215); // t216- → 0-based 215
+    assert_eq!(last.parity(), StereoParity::Minus);
 }

--- a/tests/test_invalid_inchi.rs
+++ b/tests/test_invalid_inchi.rs
@@ -122,7 +122,7 @@ fn test_unrecognized_layer_prefix() {
 #[test]
 fn test_valid_unimplemented_layers_still_parse() {
     // InChI with charge and stereo layers should parse without error.
-    let inchi_str = "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3/q+1/b2-3";
+    let inchi_str = "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3/q+1/b2-3+";
     let result = inchi_str.parse::<InChI>();
     assert!(result.is_ok(), "Known layers after main layer should be accepted: {result:?}");
 }

--- a/tests/test_invalid_inchi.rs
+++ b/tests/test_invalid_inchi.rs
@@ -46,20 +46,22 @@ fn test_not_hill_sorted() {
 fn test_unbalanced_parenthesis() {
     let inchi_str = "InChI=1S/C2H6O/c1)/";
     let result = inchi_str.parse::<InChI>();
-    assert!(
-        matches!(result, Err(Error::AtomConnectionTokenError(_))),
-        "Unbalanced parenthesis should produce an atom connection error: {result:?}"
+    assert_eq!(
+        result,
+        Err(Error::AtomConnectionTokenError(
+            AtomConnectionTokenError::ClosingBracketBeforeOpeningBracket
+        ))
     );
 }
 
 #[test]
 fn test_self_loop_comma() {
-    // TODO: The connection layer parser does not detect self-loops introduced
-    // via branch notation like `16(4,16(...))` where atom 16 connects to itself
-    // through a comma-separated branch.
     let inchi_str = "InChI=1S/C16H25NS/c1-12(2)13-7-5-8-15(3)9-6-10-16(4,16(13)15)17-11-18/h13-14H,1,5-10H2,2-4H3/t13-,14-,15+,16-/m1/s1";
     let result = inchi_str.parse::<InChI>();
-    assert!(result.is_ok(), "Known limitation: self-loop via branch not yet detected: {result:?}");
+    assert_eq!(
+        result,
+        Err(Error::AtomConnectionTokenError(AtomConnectionTokenError::SelfLoopDetected(16)))
+    );
 }
 
 #[test]
@@ -75,14 +77,12 @@ fn test_self_loop_dash() {
 #[test]
 fn test_self_loop_parenthesis() {
     // The string has two self-loops: `12(12)` and `5-5`.
-    // The parser encounters `5-5` (dash-based self-loop) and detects it,
-    // but the parenthesis-based `12(12)` is not yet detected.
-    // TODO: Detect self-loops in parenthesized branches like `12(12)`.
+    // The parser now encounters `12(12)` first (parenthesis-based self-loop).
     let inchi_str = "InChI=1S/C16H25NS/c1-12(12)13-7-5-5-15(3)9-6-10-16(4,16(13)15)17-11-18/h13-14H,1,5-10H2,2-4H3/t13-,14-,15+,16-/m1/s1";
     let result = inchi_str.parse::<InChI>();
     assert_eq!(
         result,
-        Err(Error::AtomConnectionTokenError(AtomConnectionTokenError::SelfLoopDetected(5)))
+        Err(Error::AtomConnectionTokenError(AtomConnectionTokenError::SelfLoopDetected(12)))
     );
 }
 

--- a/tests/test_pubchem.rs
+++ b/tests/test_pubchem.rs
@@ -18,7 +18,7 @@ use std::{
 
 use csv::ReaderBuilder;
 use flate2::read::GzDecoder;
-use inchi_parser::{errors::Error, inchi::InChI};
+use inchi_parser::inchi::InChI;
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::Deserialize;
 
@@ -110,7 +110,7 @@ fn validate_pubchem_inchi(file_path: &Path) -> Result<(), Box<dyn std::error::Er
         pb.inc(1);
 
         match compound.inchi.parse::<InChI>() {
-            Ok(_) | Err(Error::UnimplementedFeature(_)) => {}
+            Ok(_) => {}
             Err(e) => {
                 let error_key = e.to_string();
                 let entry = error_examples.entry(error_key).or_default();


### PR DESCRIPTION
Added support for the stereochemistry layers, building on top of the isotope branch. Surprisingly less cursed than expected, only a couple weird errors from pubchem which are now corrected. With this, the 1S parsing should be done. Next PR will be for Display.